### PR TITLE
Automatically publish releases for new tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,6 @@ on:
     tags:
       - v*
 
-    tags-ignore:
-      - "*-alpha"
-      - "*-beta"
-
 jobs:
   release:
     name: Release


### PR DESCRIPTION
### Objectives

This pull request adds a GitHub Actions workflow that publishes a release each time a new tag is pushed.